### PR TITLE
feat: Add Flask HTTP server for event handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,5 @@ COPY setup.py /opt/ai-ticket/
 COPY requirements.txt /opt/ai-ticket/
 COPY ./src/ /opt/ai-ticket/src/
 RUN pip install .
+EXPOSE 5000
+CMD ["python", "-m", "src.ai_ticket.server"]

--- a/README.md
+++ b/README.md
@@ -136,11 +136,13 @@ The primary method for running the system is using Docker Compose.
     docker-compose up --build
     ```
     The `--build` flag ensures the image is built with any local changes. For subsequent runs, you can omit it if the image hasn't changed.
+    The service will now be listening for POST requests on `http://localhost:5000/event`.
 
 3.  **Run in Detached Mode**:
     ```bash
     docker-compose up -d
     ```
+    The service will now be listening for POST requests on `http://localhost:5000/event`.
 
 4.  **View Logs**:
     ```bash
@@ -152,13 +154,19 @@ The primary method for running the system is using Docker Compose.
     docker-compose down
     ```
 
-The `ai_ticket` service, once running, will process events. The exact mechanism for sending events to it (e.g., an HTTP endpoint if exposed by the Python application, or another message queue) depends on how the `ENTRYPOINT` or `CMD` in the `Dockerfile` is configured to run the Python application. The current setup implies the Python application itself would need to implement the listening mechanism (e.g., a simple web server).
+The `ai_ticket` service, once running, exposes an HTTP endpoint to receive events.
 
 ## Examples
-The `ai_ticket` service will process events sent to it (the mechanism for sending events, e.g. HTTP endpoint, would need to be defined or is part of how the Docker image's `ENTRYPOINT` or `CMD` is configured). It then queries the configured KoboldCPP backend.
+The `ai_ticket` service now exposes an HTTP endpoint to receive events. You can send a POST request with a JSON payload to `http://localhost:5000/event` when the service is running via Docker Compose.
 
+Here's an example using `curl`:
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"content": "Explain gravity to a five-year-old."}' \
+     http://localhost:5000/event
+```
 
-The main way to interact with the `ai-ticket` system programmatically (if you were importing it as a Python library, or for testing) is via its `on_event` function.
+The following Python examples demonstrate the direct usage of the `on_event` function, which is the core logic behind the HTTP endpoint. While you can use `on_event` directly if you integrate `ai_ticket` as a Python library, the primary interaction method for the deployed service is via the HTTP endpoint described above.
 
 ```python
 import json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
     restart: unless-stopped
+    ports:
+      - "5000:5000"
     # Optional: Add environment variables for KOBOLDCPP_API_URL if needed here
     # environment:
     #   - KOBOLDCPP_API_URL=http://host.docker.internal:5001/api

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ black
 isort
 pytest
 pytest-mock
+Flask>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-dotenv
 requests
+Flask>=2.0

--- a/src/ai_ticket/server.py
+++ b/src/ai_ticket/server.py
@@ -1,0 +1,39 @@
+import os
+from flask import Flask, request, jsonify
+from ai_ticket.events.inference import on_event
+import logging
+
+# Basic logging configuration
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+app = Flask(__name__)
+
+@app.route("/event", methods=["POST"])
+def handle_event():
+    if not request.is_json:
+        logging.error("Request is not JSON")
+        return jsonify({"error": "invalid_request", "details": "Request must be JSON."}), 400
+
+    event_data = request.get_json()
+    logging.info(f"Received event data: {event_data}")
+
+    response = on_event(event_data)
+
+    if "error" in response:
+        logging.error(f"Error processing event: {response}")
+        # Determine status code based on error type if possible, otherwise default
+        status_code = 400 # Default for client-side errors
+        if response.get("error") == "configuration_error":
+            status_code = 500
+        elif response.get("error") == "api_connection_error":
+            status_code = 503 # Service Unavailable
+        # Add more specific error to status_code mappings if needed
+        return jsonify(response), status_code
+
+    logging.info(f"Successfully processed event, response: {response}")
+    return jsonify(response), 200
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 5000))
+    # Make sure to run with host='0.0.0.0' to be accessible from outside the container
+    app.run(host="0.0.0.0", port=port)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,77 @@
+import pytest
+import json
+from src.ai_ticket.server import app as flask_app # Import the Flask app instance
+
+@pytest.fixture
+def app():
+    yield flask_app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_handle_event_success(client, mocker):
+    # Mock the on_event function to avoid actual backend calls
+    mock_on_event = mocker.patch('src.ai_ticket.server.on_event')
+    mock_on_event.return_value = {"completion": "Test completion"}
+
+    payload = {"content": "Test prompt"}
+    response = client.post("/event", json=payload)
+
+    assert response.status_code == 200
+    response_data = json.loads(response.data)
+    assert response_data == {"completion": "Test completion"}
+    mock_on_event.assert_called_once_with(payload)
+
+def test_handle_event_missing_content(client, mocker):
+    # Mock on_event to ensure it's not called if input validation fails early
+    # or to control its return if server.py calls it before its own validation.
+    # The current server.py calls on_event, so we mock its error return.
+    mock_on_event = mocker.patch('src.ai_ticket.server.on_event')
+    mock_on_event.return_value = {"error": "missing_content_field", "details": "'content' field is missing..."}
+
+    payload = {"some_other_key": "some_value"} # Missing 'content'
+    response = client.post("/event", json=payload)
+
+    assert response.status_code == 400 # Assuming server.py maps this error to 400
+    response_data = json.loads(response.data)
+    assert response_data["error"] == "missing_content_field"
+    mock_on_event.assert_called_once_with(payload)
+
+
+def test_handle_event_not_json(client, mocker):
+    # Mock on_event to ensure it's not called for non-JSON requests
+    mock_on_event = mocker.patch('src.ai_ticket.server.on_event')
+
+    response = client.post("/event", data="not a json string", content_type="text/plain")
+
+    assert response.status_code == 400
+    response_data = json.loads(response.data)
+    assert response_data["error"] == "invalid_request"
+    assert "Request must be JSON" in response_data["details"]
+    mock_on_event.assert_not_called() # on_event should not be called if request is not JSON
+
+def test_handle_event_on_event_error(client, mocker):
+    # Test a scenario where on_event returns a specific error
+    mock_on_event = mocker.patch('src.ai_ticket.server.on_event')
+    mock_on_event.return_value = {"error": "api_connection_error", "details": "Could not connect"}
+
+    payload = {"content": "Test prompt for API error"}
+    response = client.post("/event", json=payload)
+
+    assert response.status_code == 503 # As per server.py logic for this error
+    response_data = json.loads(response.data)
+    assert response_data["error"] == "api_connection_error"
+    mock_on_event.assert_called_once_with(payload)
+
+def test_handle_event_prompt_extraction_failed(client, mocker):
+    mock_on_event = mocker.patch('src.ai_ticket.server.on_event')
+    mock_on_event.return_value = {"error": "prompt_extraction_failed", "details": "Could not derive prompt."}
+
+    payload = {"content": {"unexpected_structure": True}} # Example that might cause extraction failure
+    response = client.post("/event", json=payload)
+
+    assert response.status_code == 400 # Default error code for client-side issues
+    response_data = json.loads(response.data)
+    assert response_data["error"] == "prompt_extraction_failed"
+    mock_on_event.assert_called_once_with(payload)


### PR DESCRIPTION
This commit introduces a Flask-based web server to the ai-ticket application, enabling it to receive events via HTTP POST requests.

Key changes include:
- Added `Flask` to dependencies.
- Created `src/ai_ticket/server.py` which defines a `/event` endpoint. This endpoint receives JSON payloads and passes them to the existing `on_event` function.
- Updated `Dockerfile` to expose port 5000 and set the CMD to run the Flask server.
- Updated `docker-compose.yml` to map port 5000 from the host to the container.
- Added Pytest unit tests for the new `/event` endpoint in `tests/test_server.py`, mocking the underlying `on_event` logic to ensure tests are isolated.
- Updated `README.md` to document the new HTTP endpoint, provide usage examples (including a `curl` command), and reflect changes in running the application.

These changes make the application network-accessible, allowing it to be integrated into larger systems by receiving external event triggers for LLM processing.